### PR TITLE
ADD: batches support in the results export due to #47

### DIFF
--- a/vulyk/cli/batches.py
+++ b/vulyk/cli/batches.py
@@ -37,3 +37,10 @@ def validate_batch(ctx, param, value):
             'Batch with id {id} already exists'.format(id=value))
     else:
         return value
+
+def batches_list():
+    """
+    :return: List of batches IDs to validate CLI input
+    :rtype : list[str]
+    """
+    return Batch.objects.scalar('id')

--- a/vulyk/cli/db.py
+++ b/vulyk/cli/db.py
@@ -90,17 +90,18 @@ def _load_tasks_file(task_id, path, batch):
     return i
 
 
-def export_tasks(task_id, path, closed):
+def export_tasks(task_id, path, batch, closed):
     """
     :type task_id: vulyk.models.task_types.AbstractTaskType
     :type path: str | unicode
+    :type batch: str | unicode
     :type closed: boolean
     """
     i = 0
 
     try:
         with open(path, 'w+') as f:
-            for report in task_id.export_reports(closed):
+            for report in task_id.export_reports(batch, closed):
                 f.write(json.dumps(report) + os.linesep)
                 i += 1
 

--- a/vulyk/control.py
+++ b/vulyk/control.py
@@ -80,10 +80,14 @@ def load(task_type, path, batch):
                 type=click.Path(file_okay=True,
                                 writable=True,
                                 resolve_path=True))
+@click.option('--batch',
+              default=app.config['DEFAULT_BATCH'],
+              type=click.Choice(_batches.batches_list()),
+              help='Specify the batch id tasks should be loaded into')
 @click.option('--export-all', 'export_all', default=False, is_flag=True)
-def export(task_type, path, export_all):
+def export(task_type, path, batch, export_all):
     """Exports answers on closed tasks to json."""
-    _db.export_tasks(TASKS_TYPES[task_type], path, not export_all)
+    _db.export_tasks(TASKS_TYPES[task_type], path, batch, not export_all)
 
 
 @cli.group('group')

--- a/vulyk/models/task_types.py
+++ b/vulyk/models/task_types.py
@@ -86,20 +86,23 @@ class AbstractTaskType(object):
             # TODO: review list of exceptions, any fallback actions if needed
             raise TaskImportError('Can\'t load task: {0}'.format(e))
 
-    def export_reports(self, closed=True, qs=None):
-        """Exports results
-        io is left out of scope here as well
+    def export_reports(self, batch, closed=True, qs=None):
+        """Exports results. IO is left out of scope here as well
 
-        Args:
-            qs: Queryset, an optional argument. Default value is QS that
-            exports all tasks with amount of answers > redundancy
-        Returns:
-            Generator of lists of dicts with results
+        :param batch: Certain batch to extract
+        :type batch: str | unicode
+        :param closed: Specify if we need to export only closed tasks reports
+        :type closed: bool
+        :param qs: Queryset, an optional argument. Default value is QS that
+                   exports all tasks with amount of answers > redundancy
+        :type qs: QuerySet
+
+        :returns: Generator of lists of dicts with results
+        :rtype: __generator[list[dict]]
         """
 
         if qs is None:
-            # Not really tested yet
-            qs = self.task_model.objects(closed=closed)
+            qs = self.task_model.objects(batch=batch, closed=closed)
 
         for task in qs:
             yield [answer.as_dict()

--- a/vulyk/models/task_types.py
+++ b/vulyk/models/task_types.py
@@ -100,9 +100,8 @@ class AbstractTaskType(object):
         :returns: Generator of lists of dicts with results
         :rtype: __generator[list[dict]]
         """
-        query = Q(batch=batch, closed=closed) if closed else Q(batch=batch)
-
         if qs is None:
+            query = Q(batch=batch, closed=closed) if closed else Q(batch=batch)
             qs = self.task_model.objects(query)
 
         for task in qs:

--- a/vulyk/models/task_types.py
+++ b/vulyk/models/task_types.py
@@ -100,9 +100,10 @@ class AbstractTaskType(object):
         :returns: Generator of lists of dicts with results
         :rtype: __generator[list[dict]]
         """
+        query = Q(batch=batch, closed=closed) if closed else Q(batch=batch)
 
         if qs is None:
-            qs = self.task_model.objects(batch=batch, closed=closed)
+            qs = self.task_model.objects(query)
 
         for task in qs:
             yield [answer.as_dict()


### PR DESCRIPTION
Also a migration to get every task associated with a batch:

```js
db.batches.insert({ "_id" : "default", "_cls" : "Batch", "taskType" : "declaration_task", "tasksCount" : 850, "tasksProcessed" : 850 });
db.tasks.update({'batch': {'$exists': 0}}, {'$set': {'batch': 'default'}}, false, true);
```