### PR TITLE
Record activity patterns during task solving

### DIFF
--- a/tests/test_task_types.py
+++ b/tests/test_task_types.py
@@ -12,7 +12,11 @@ from unittest.mock import patch, Mock
 
 from vulyk.ext.leaderboard import LeaderBoardManager
 from vulyk.models.exc import (
-    TaskImportError, TaskNotFoundError, TaskValidationError)
+    TaskImportError,
+    TaskSkipError,
+    TaskNotFoundError,
+    TaskValidationError)
+from vulyk.models.stats import WorkSession
 from vulyk.models.task_types import AbstractTaskType
 from vulyk.models.tasks import AbstractTask, AbstractAnswer, Batch
 from vulyk.models.user import User, Group
@@ -36,6 +40,7 @@ class TestTaskTypes(BaseTest):
         AbstractTask.objects.delete()
         AbstractAnswer.objects.delete()
         Batch.objects.delete()
+        WorkSession.objects.delete()
 
         super().tearDown()
 
@@ -447,6 +452,57 @@ class TestTaskTypes(BaseTest):
                          ' is available')
     # endregion Next task
 
+    # region Record activity
+    def test_update_session_normal(self):
+        task_type = FakeType({})
+        user = User(username='user0', email='user0@email.com').save()
+        task = task_type.task_model(
+            id='task0',
+            task_type=task_type.type_name,
+            batch='any_batch',
+            closed=False,
+            users_count=0,
+            users_processed=[],
+            users_skipped=[],
+            task_data={'data': 'data'}).save()
+        duration = 50
+
+        task_type._work_session_manager.start_work_session(task, user)
+        task_type.record_activity(user.id, task.id, duration)
+
+        session = WorkSession.objects.get(user=user.id, task=task)
+
+        self.assertEqual(session.activity, duration)
+
+    def test_update_session_twice(self):
+        task_type = FakeType({})
+        user = User(username='user0', email='user0@email.com').save()
+        task = task_type.task_model(
+            id='task0',
+            task_type=task_type.type_name,
+            batch='any_batch',
+            closed=False,
+            users_count=0,
+            users_processed=[],
+            users_skipped=[],
+            task_data={'data': 'data'}).save()
+        duration = 50
+
+        task_type._work_session_manager.start_work_session(task, user)
+
+        task_type.record_activity(user.id, task.id, duration)
+        task_type.record_activity(user.id, task.id, duration)
+
+        session = WorkSession.objects.get(user=user.id, task=task)
+
+        self.assertEqual(session.activity, duration * 2)
+
+    def test_update_session_not_found(self):
+        fake_type = FakeType({})
+        self.assertRaises(TaskNotFoundError,
+                          lambda: fake_type.record_activity('fake_id', '', 0))
+    # endregion Record activity
+
     # region Skip task
     def test_skip_task_normal(self):
         task_type = FakeType({})
@@ -461,6 +517,7 @@ class TestTaskTypes(BaseTest):
             users_skipped=[],
             task_data={'data': 'data'}).save()
 
+        task_type._work_session_manager.start_work_session(task, user)
         task_type.skip_task(task.id, user)
 
         task = task_type.task_model.objects.get(id=task.id)
@@ -480,8 +537,11 @@ class TestTaskTypes(BaseTest):
             users_skipped=[],
             task_data={'data': 'data'}).save()
 
+        task_type._work_session_manager.start_work_session(task, user)
         task_type.skip_task(task.id, user)
-        task_type.skip_task(task.id, user)
+
+        self.assertRaises(TaskSkipError,
+                          lambda: task_type.skip_task(task.id, user))
 
         task = task_type.task_model.objects.get(id=task.id)
 
@@ -518,7 +578,6 @@ class TestTaskTypes(BaseTest):
 
         self.assertEqual(task.users_count, 1)
         self.assertEqual(task.users_processed, [user])
-        self.assertEqual(ws.answer, answer)
         self.assertEqual(ws.answer, answer)
         self.assertEqual(user.processed, 1)
 
@@ -589,8 +648,6 @@ class TestTaskTypes(BaseTest):
 
         self.assertEqual(batch.tasks_processed, 1)
 
-    # endregion On task done
-
     def test_on_done_raises_not_found(self):
         self.assertRaises(TaskNotFoundError,
                           lambda: FakeType({}).on_task_done(
@@ -598,7 +655,9 @@ class TestTaskTypes(BaseTest):
                               'fake_id',
                               {})
                           )
+    # endregion On task done
 
+    # region Leaders
     def test_proxy_leaderboard_get_leaders(self):
         fake_type = FakeType({})
         fake_manager = Mock(spec=LeaderBoardManager)
@@ -621,6 +680,7 @@ class TestTaskTypes(BaseTest):
 
         self.assertEqual(fake_type.get_leaderboard(), answer,
                          'AbstractTaskType should not change leaderboard')
+    # endregion Leaders
 
 
 if __name__ == '__main__':

--- a/vulyk/ext/worksession.py
+++ b/vulyk/ext/worksession.py
@@ -94,7 +94,7 @@ class WorkSessionManager:
                              task=task)
             duration = datetime.now() - session.start_time
 
-            if duration.total_seconds() > seconds > 0:
+            if duration.total_seconds() > seconds + session.activity > 0:
                 session.activity += seconds
                 session.save()
 

--- a/vulyk/ext/worksession.py
+++ b/vulyk/ext/worksession.py
@@ -1,9 +1,11 @@
 # -*- coding: utf-8 -*-
 from datetime import datetime
+import logging
 
 from flask_mongoengine import Document
+from mongoengine.errors import OperationError
 
-from vulyk.models.exc import WorkSessionLookUpError
+from vulyk.models.exc import WorkSessionLookUpError, WorkSessionUpdateError
 
 __all__ = [
     'WorkSessionManager'
@@ -15,8 +17,8 @@ class WorkSessionManager:
     This class is responsible for accounting of work-sessions.
     Every time we give a task to user, a new session record is being created.
     If user skips the task, we mark it as skipped and delete the session.
-    When user finishes the task, we close the session having added the timestamp
-    of the event.
+    When user finishes the task, we close the session having added the
+    timestamp of the event.
     Thus we're able to perform any kind of data mining and stats counting using
     the data later.
 
@@ -33,6 +35,7 @@ class WorkSessionManager:
         assert issubclass(work_session_model, Document), \
             'You should define working session model properly'
 
+        self._logger = logging.getLogger('vulyk.app')
         self.work_session = work_session_model
 
     def start_work_session(self, task, user_id):
@@ -47,30 +50,65 @@ class WorkSessionManager:
         :param task: Given task
         :type task: vulyk.models.tasks.AbstractTask
         :param user_id: ID of user, who gets new task
-        :type user_id: bytes, str, bson.ObjectId
+        :type user_id: bson.ObjectId
+
+        :raises:
+            WorkSessionUpdateError -- can not start a session
         """
-        self.work_session \
-            .objects(user=user_id,
-                     task=task) \
-            .modify(upsert=True,
-                    set__start_time=datetime.now(),
-                    set__activity=0)
+        try:
+            existing = self.work_session \
+                .objects(user=user_id,
+                         task=task) \
+                .modify(upsert=True,
+                        set__start_time=datetime.now(),
+                        set__activity=0)
+
+            if existing is not None:
+                self._logger.debug(
+                    'Overwriting existing unfinished session for user %s and '
+                    'task %s.', user_id, task.id)
+        except OperationError as err:
+            msg = 'Can not create a session: {}.'.format(err)
+            raise WorkSessionUpdateError(msg)
 
     def record_activity(self, task, user_id, seconds):
         """
         Update an activity counter.
+        The intention is to find out how much time was actually spent
+        working on the task, excluding sexting, brewing coffee and jogging.
 
-        :param task: Current task
+        :param task: The task the session belongs to.
         :type task: vulyk.models.tasks.AbstractTask
-        :param user_id: ID of user, who gets new task
-        :type user_id: bytes, str, bson.ObjectId
+        :param user_id: ID of current user
+        :type user_id: bson.ObjectId
         :param seconds: User was active for
         :type seconds: int
+
+        :raises:
+            WorkSessionLookUpError -- session is not found;
+            WorkSessionUpdateError -- can not update the session
         """
-        self.work_session \
-            .objects(user=user_id,
-                     task=task) \
-            .modify(inc__activity=seconds)
+        try:
+            session = self.work_session \
+                .objects.get(user=user_id,
+                             task=task)
+            duration = datetime.now() - session.start_time
+
+            if duration.total_seconds() > seconds > 0:
+                session.activity += seconds
+                session.save()
+
+                self._logger.debug(
+                    'Added %s seconds of activities for user %s and task %s.',
+                    user_id, task.id)
+            else:
+                msg = 'Can not update the session {} for user {}. Value: {}.' \
+                    .format(session.id, user_id, seconds)
+                raise WorkSessionUpdateError(msg)
+        except self.work_session.DoesNotExist:
+            msg = 'Did not found a session for user {} and task {}.'.format(
+                user_id, task.id)
+            raise WorkSessionLookUpError(msg)
 
     def end_work_session(self, task, user_id, answer):
         """
@@ -81,26 +119,30 @@ class WorkSessionManager:
         :param task: Given task
         :type task: vulyk.models.tasks.AbstractTask
         :param user_id: ID of user, who finishes a task
-        :type user_id: bytes, str, bson.ObjectId
+        :type user_id: bson.ObjectId
         :param answer: Given answer
         :type answer: vulyk.models.tasks.AbstractAnswer
 
-        :raises: vulyk.models.exc.WorkSessionLookUpError - if session was not
-         found
+        :raises:
+            WorkSessionLookUpError -- session is not found;
+            WorkSessionUpdateError -- can not close the session
         """
         # TODO: store id of active session in cookies or elsewhere
-        rs = self.work_session \
-            .objects(user=user_id, task=task) \
-            .order_by('-start_time')
+        try:
+            rs = self.work_session \
+                .objects(user=user_id, task=task) \
+                .order_by('-start_time')
 
-        if rs.count() > 0:
-            rs.first().update(
-                set__end_time=datetime.now(),
-                set__answer=answer)
-        else:
-            msg = 'No session was found for {0}'.format(answer)
+            if rs.count() > 0:
+                rs.first().update(
+                    set__end_time=datetime.now(),
+                    set__answer=answer)
+            else:
+                msg = 'No session was found for {0}'.format(answer)
 
-            raise WorkSessionLookUpError(msg)
+                raise WorkSessionLookUpError(msg)
+        except OperationError as e:
+            raise WorkSessionUpdateError(e)
 
     def delete_work_session(self, task, user_id):
         """
@@ -109,19 +151,23 @@ class WorkSessionManager:
         :param task: Given task
         :type task: vulyk.models.tasks.AbstractTask
         :param user_id: ID of user, who skips a task
-        :type user_id: bytes, str, bson.ObjectId
+        :type user_id: bson.ObjectId
 
-        :raises: vulyk.models.exc.WorkSessionLookUpError - if session was not
-         found
+        :raises:
+            WorkSessionLookUpError -- session is not found;
+            WorkSessionUpdateError -- can not delete the session
         """
-        rs = self.work_session \
-            .objects(user=user_id, task=task) \
-            .order_by('-start_time')
+        try:
+            rs = self.work_session \
+                .objects(user=user_id, task=task) \
+                .order_by('-start_time')
 
-        if rs.count() > 0:
-            rs.first().delete()
-        else:
-            msg = 'No session was found for {0} & {1}'.format(
-                user_id, task.id)
+            if rs.count() > 0:
+                rs.first().delete()
+            else:
+                msg = 'No session was found for {0} & {1}'.format(
+                    user_id, task.id)
 
-            raise WorkSessionLookUpError(msg)
+                raise WorkSessionLookUpError(msg)
+        except OperationError as e:
+            raise WorkSessionUpdateError(e)

--- a/vulyk/models/exc.py
+++ b/vulyk/models/exc.py
@@ -9,6 +9,7 @@ __all__ = [
     'TaskNotFoundError',
     'TaskSaveError',
     'TaskPermissionError',
+    'TaskUpdateError',
     'TaskSkipError',
     'TaskValidationError',
     'WorkSessionLookUpError'
@@ -16,6 +17,10 @@ __all__ = [
 
 
 class TaskImportError(Exception):
+    pass
+
+
+class TaskUpdateError(Exception):
     pass
 
 

--- a/vulyk/models/exc.py
+++ b/vulyk/models/exc.py
@@ -9,18 +9,14 @@ __all__ = [
     'TaskNotFoundError',
     'TaskSaveError',
     'TaskPermissionError',
-    'TaskUpdateError',
     'TaskSkipError',
     'TaskValidationError',
-    'WorkSessionLookUpError'
+    'WorkSessionLookUpError',
+    'WorkSessionUpdateError'
 ]
 
 
 class TaskImportError(Exception):
-    pass
-
-
-class TaskUpdateError(Exception):
     pass
 
 
@@ -45,4 +41,8 @@ class TaskNotFoundError(Exception):
 
 
 class WorkSessionLookUpError(Exception):
+    pass
+
+
+class WorkSessionUpdateError(Exception):
     pass

--- a/vulyk/models/stats.py
+++ b/vulyk/models/stats.py
@@ -27,9 +27,9 @@ class WorkSession(Document):
                           required=True)
     answer = ReferenceField(AbstractAnswer, reverse_delete_rule=CASCADE)
 
-    start_time = DateTimeField(required=True, default=datetime.now())
+    start_time = DateTimeField(required=True)
     end_time = DateTimeField(required=False)
-    corrections = IntField()
+    activity = IntField()
 
     meta = {
         'collection': 'work_sessions',

--- a/vulyk/models/task_types.py
+++ b/vulyk/models/task_types.py
@@ -21,6 +21,7 @@ from vulyk.ext.worksession import WorkSessionManager, WorkSessionLookUpError
 from vulyk.models.exc import (
     TaskImportError,
     TaskSaveError,
+    TaskUpdateError,
     TaskSkipError,
     TaskValidationError,
     TaskNotFoundError
@@ -73,7 +74,7 @@ class AbstractTaskType:
          when instantiating plugins. Could be useful for plugins.
         :type settings: dict
         """
-        self._logger = logging.getLogger(self.__class__.__name__)
+        self._logger = logging.getLogger('vulyk.app')
 
         self._leaderboard_manager = \
             self._leaderboard_manager or LeaderBoardManager(self.type_name,
@@ -141,6 +142,9 @@ class AbstractTaskType:
                     task_data=task))
 
             self.task_model.objects.insert(bulk)
+
+            self._logger.debug('Inserted %s tasks in batch %s for plugin <%s>',
+                               len(bulk), batch, self.name)
         except errors as e:
             # TODO: review list of exceptions, any fallback actions if needed
             raise TaskImportError('Can\'t load task: {}'.format(e))
@@ -209,8 +213,12 @@ class AbstractTaskType:
             # Not sure if we should do that here on GET requests
             self._work_session_manager.start_work_session(task, user.id)
 
+            self._logger.debug('Assigned task %s to user %s', task.id, user.id)
+
             return task.as_dict()
         else:
+            self._logger.debug('No suitable task found for  user %s', user.id)
+
             return {}
 
     def _get_next_task(self, user):
@@ -264,6 +272,36 @@ class AbstractTaskType:
         else:
             return None
 
+    def record_activity(self, user_id, task_id, seconds):
+        """
+        Marks given task as a skipped by a given user
+        Assumes that user is eligible for this kind of tasks
+
+        :param task_id: Current task
+        :type task_id: str
+        :param user_id: ID of user, who gets new task
+        :type user_id: bytes, str, bson.ObjectId
+        :param seconds: User was active for
+        :type seconds: int
+
+        :raises: TaskSkipError, TaskNotFoundError
+        """
+        try:
+            task = self.task_model.objects.get(id=task_id,
+                                               task_type=self.type_name)
+
+            self._work_session_manager.record_activity(task, user_id, seconds)
+
+            self._logger.debug('recording %s seconds of activity of user %s '
+                               'on task %s', seconds, user_id, task_id)
+        except self.task_model.DoesNotExist:
+            raise TaskNotFoundError()
+        except OperationError as err:
+            raise TaskUpdateError('Can not skip the task: {0}.'.format(err))
+        except WorkSessionLookUpError:
+            raise TaskUpdateError('Haven\'t found a worksession for user %s '
+                                  'and task %s.', user_id, task_id)
+
     def skip_task(self, task_id, user):
         """
         Marks given task as a skipped by a given user
@@ -274,23 +312,26 @@ class AbstractTaskType:
         :param user: an instance of User model who provided an answer
         :type user: models.User
 
-        :raises: TaskSkipError
+        :raises: TaskSkipError, TaskNotFoundError
         """
         try:
             task = self.task_model.objects.get(
-                id=task_id, task_type=self.type_name)
+                id=task_id,
+                task_type=self.type_name)
 
             task.update(add_to_set__users_skipped=user)
             self._work_session_manager.delete_work_session(task, user.id)
+
+            self._logger.debug('User %s skipped the task %s', user.id, task_id)
         except self.task_model.DoesNotExist:
             raise TaskNotFoundError()
         except NotUniqueError as err:
             raise TaskSkipError(err)
         except OperationError as err:
-            raise TaskSkipError('Can not skip the task: {0}'.format(err))
+            raise TaskSkipError('Can not skip the task: {0}.'.format(err))
         except WorkSessionLookUpError:
-            # TODO: logging
-            pass
+            raise TaskSkipError('Haven\'t found a worksession for user %s '
+                                'and task %s.', user.id, task_id)
 
     def on_task_done(self, user, task_id, result):
         """
@@ -315,7 +356,7 @@ class AbstractTaskType:
                 task_type=self.type_name)
         except self.task_model.DoesNotExist:
             raise TaskNotFoundError('Task with ID {id} not found while '
-                                    'trying to save an answer from {user!r}'
+                                    'trying to save an answer from {user!r}.'
                                     .format(id=task_id, user=user))
 
         try:
@@ -332,6 +373,8 @@ class AbstractTaskType:
             user.update(inc__processed=1)
             # update stats record
             self._work_session_manager.end_work_session(task, user, answer)
+
+            self._logger.debug('User %s has done task %s', user.id, task_id)
 
             if closed and task.batch is not None:
                 batch_id = task.batch.id

--- a/vulyk/static/scripts/base.js
+++ b/vulyk/static/scripts/base.js
@@ -42,13 +42,17 @@ var Vulyk = Vulyk || {
                     vus.task_id = data.result.task.id;
                     vus.body.trigger("vulyk.next", data);
                 }
-            ).fail(function(data) {
+            ).fail(function (data) {
                 vus.body.trigger("vulyk.task_error", data.responseJSON);
             });
         },
         skip_task: function () {
             var vu = this,
                 vus = vu.State;
+
+            if (vus.task_id === 0) {
+                return;
+            }
 
             if (typeof(ga) !== "undefined") {
                 ga('send', 'event', 'Task', 'Skip', vus.task_type);
@@ -57,7 +61,7 @@ var Vulyk = Vulyk || {
             $.post(
                 "/type/" + vus.task_type + "/skip/" + vus.task_id,
                 {},
-                function(data){
+                function (data) {
                     vu.load_next();
                 }
             );
@@ -73,7 +77,7 @@ var Vulyk = Vulyk || {
             $.post(
                 "/type/" + vus.task_type + "/done/" + vus.task_id,
                 {result: JSON.stringify(result)},
-                function(data) {
+                function (data) {
                     vu.load_next();
                 });
         },
@@ -96,14 +100,14 @@ var Vulyk = Vulyk || {
                     vu.load_next();
                 }
 
-                vus.body.on("vulyk.next", function(e, data) {
+                vus.body.on("vulyk.next", function (e, data) {
                     $("a#save-button, a#skip-button").removeClass("disabled");
                     vus.stats
                         .find("dd:eq(0)")
-                            .html(data.result.stats.total)
+                        .html(data.result.stats.total)
                         .end()
                         .find("dd:eq(1)")
-                            .html(data.result.stats.position)
+                        .html(data.result.stats.position)
                         .end()
                         .show();
                 });

--- a/vulyk/templates/base/task.html
+++ b/vulyk/templates/base/task.html
@@ -30,9 +30,9 @@
 
         <a class="btn btn-lg btn-default" id="save-button" href="#">
 
-            {% if config.LANGUAGE == 'ua' %}Надіслати форму:
-            {% elif config.LANGUAGE == 'ru' %}Отправить:
-            {% else %}Submit:
+            {% if config.LANGUAGE == 'ua' %}Надіслати форму
+            {% elif config.LANGUAGE == 'ru' %}Отправить
+            {% else %}Submit
             {% endif %}
             <!--small>(alt+enter)</small-->
 
@@ -40,9 +40,9 @@
         </a>
         <a class="btn" id="skip-button" href="#">
 
-            {% if config.LANGUAGE == 'ua' %}Пропустити завдання:
-            {% elif config.LANGUAGE == 'ru' %}Пропустить задание:
-            {% else %}Skip task:
+            {% if config.LANGUAGE == 'ua' %}Пропустити завдання
+            {% elif config.LANGUAGE == 'ru' %}Пропустить задание
+            {% else %}Skip task
             {% endif %}
             <!--small>(esc)</small-->
 


### PR DESCRIPTION
CHG: redundant field `WorkSession.corrections` is now renamed to `WorkSession.activity`;
CHG: static start time issue is now gone;
CHG: extended logging within `AbstractTaskType`;
ADD: a new method to record activity duration is added to `WorkSessionManager` and proxied in `AbstractTaskType`;