### PR TITLE
Global rework. Step 3: Gamification mechanics. Achievements allocation

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,7 +3,7 @@ from . import (test_cli, test_user_model, test_task_types, test_utils,
                test_user_login, test_leaderboard, test_worksessions)
 from .gamification import (test_event_models, test_rule_parsing,
                            test_state_models, test_fund_models,
-                           test_query_builders)
+                           test_query_builders, test_allocation)
 
 __all__ = [
     'test_cli',
@@ -18,5 +18,6 @@ __all__ = [
     'test_query_builders',
     'test_state_models',
     'test_rule_parsing',
-    'test_event_models'
+    'test_event_models',
+    'test_allocation'
 ]

--- a/tests/gamification/test_event_models.py
+++ b/tests/gamification/test_event_models.py
@@ -52,14 +52,14 @@ class TestEventModels(BaseTest):
     def tearDown(self):
         super().tearDown()
 
-        User.drop_collection()
-        Group.drop_collection()
-        AbstractTask.drop_collection()
-        AbstractAnswer.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
+        AbstractTask.objects.delete()
+        AbstractAnswer.objects.delete()
 
-        EventModel.drop_collection()
-        FundModel.drop_collection()
-        RuleModel.drop_collection()
+        EventModel.objects.delete()
+        FundModel.objects.delete()
+        RuleModel.objects.delete()
 
     def test_no_achievements_ok(self):
         ev = Event.build(

--- a/tests/gamification/test_fund_models.py
+++ b/tests/gamification/test_fund_models.py
@@ -19,7 +19,7 @@ class TestFundModels(BaseTest):
     def tearDown(self):
         super().tearDown()
 
-        FundModel.drop_collection()
+        FundModel.objects.delete()
         FundModel._get_db().drop_collection('images.files')
         FundModel._get_db().drop_collection('images.chunks')
 

--- a/tests/gamification/test_query_builders.py
+++ b/tests/gamification/test_query_builders.py
@@ -334,7 +334,7 @@ class TestMongoQueryExecutor(BaseTest):
     DAY = timedelta(days=1)
 
     def tearDown(self):
-        WorkSession.drop_collection()
+        WorkSession.objects.delete()
         super().tearDown()
 
     def test_n_tasks_ok(self):
@@ -901,7 +901,7 @@ class TestRuleModel(BaseTest):
             RuleModel.from_rule(rule).save()
 
     def tearDown(self):
-        RuleModel.drop_collection()
+        RuleModel.objects.delete()
 
         super().tearDown()
 

--- a/tests/gamification/test_query_builders.py
+++ b/tests/gamification/test_query_builders.py
@@ -37,7 +37,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_n_tasks_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            batch_name=project,
+            task_type_name=project,
             badge='',
             name='',
             description='',
@@ -79,7 +79,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_n_tasks_m_days_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            batch_name=project,
+            task_type_name=project,
             badge='',
             name='',
             description='',
@@ -129,7 +129,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_n_tasks_weekends_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            batch_name=project,
+            task_type_name=project,
             badge='',
             name='',
             description='',
@@ -180,7 +180,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_m_weekends_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            batch_name=project,
+            task_type_name=project,
             badge='',
             name='',
             description='',
@@ -236,7 +236,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_m_weekends_adjacent_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            batch_name=project,
+            task_type_name=project,
             badge='',
             name='',
             description='',
@@ -297,7 +297,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_m_days_adjacent_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            batch_name=project,
+            task_type_name=project,
             badge='',
             name='',
             description='',
@@ -392,10 +392,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_n_tasks_project_ok(self):
         uid = ObjectId()
-        batch_name = 'fake_task'
+        task_type_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge='',
             name='',
             description='',
@@ -405,14 +405,14 @@ class TestMongoQueryExecutor(BaseTest):
             is_weekend=False,
             is_adjacent=False)
 
-        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.DAY, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.DAY * 2, end_time=self.NOW) \
             .save()
-        WorkSession(user=ObjectId(), task=ObjectId(), task_type=batch_name,
+        WorkSession(user=ObjectId(), task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
 
         result = MongoRuleExecutor.achieved(
@@ -422,10 +422,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_n_tasks_project_fail(self):
         uid = ObjectId()
-        batch_name = 'fake_task'
+        task_type_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge='',
             name='',
             description='',
@@ -435,14 +435,14 @@ class TestMongoQueryExecutor(BaseTest):
             is_weekend=False,
             is_adjacent=False)
 
-        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.DAY, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.DAY * 2, end_time=self.NOW) \
             .save()
-        WorkSession(user=ObjectId(), task=ObjectId(), task_type=batch_name,
+        WorkSession(user=ObjectId(), task=ObjectId(), task_type=task_type_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
 
         result = MongoRuleExecutor.achieved(
@@ -479,10 +479,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_n_tasks_m_days_project_ok(self):
         uid = ObjectId()
-        batch_name = 'fake_task'
+        task_type_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge='',
             name='',
             description='',
@@ -496,7 +496,7 @@ class TestMongoQueryExecutor(BaseTest):
             day_i = self.NOW - self.DAY * (i % 7)
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=batch_name,
+                        task_type=task_type_name,
                         start_time=day_i,
                         end_time=day_i
                         ).save()
@@ -676,10 +676,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_weekends_project(self):
         uid = ObjectId()
-        batch_name = 'fake_task'
+        task_type_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge='',
             name='',
             description='',
@@ -695,7 +695,7 @@ class TestMongoQueryExecutor(BaseTest):
             day_i = (self.NOW - to_sun) - (self.DAY * 7 * i * 2)
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=batch_name,
+                        task_type=task_type_name,
                         start_time=day_i,
                         end_time=day_i
                         ).save()
@@ -736,10 +736,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_adjacent_weekends_project(self):
         uid = ObjectId()
-        batch_name = 'fake_task'
+        task_type_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge='',
             name='',
             description='',
@@ -755,7 +755,7 @@ class TestMongoQueryExecutor(BaseTest):
             day_i = (self.NOW - to_sun) - (self.DAY * 7 * i)
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=batch_name,
+                        task_type=task_type_name,
                         start_time=day_i,
                         end_time=day_i
                         ).save()
@@ -793,10 +793,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_days_adjacent_project_ok(self):
         uid = ObjectId()
-        batch_name = 'fake_task'
+        task_type_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge='',
             name='',
             description='',
@@ -809,7 +809,7 @@ class TestMongoQueryExecutor(BaseTest):
         for i in range(1, 6):
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=batch_name,
+                        task_type=task_type_name,
                         start_time=self.NOW - self.DAY * i,
                         end_time=self.NOW - self.DAY * i
                         ).save()
@@ -821,10 +821,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_days_adjacent_project_fail(self):
         uid = ObjectId()
-        batch_name = 'fake_task'
+        task_type_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge='',
             name='',
             description='',
@@ -872,7 +872,7 @@ class TestRuleModel(BaseTest):
             rule_id=200),
         ProjectRule(
             rule_id=300,
-            batch_name='batch_1',
+            task_type_name='batch_1',
             badge='',
             name='rule_3',
             description='',
@@ -883,7 +883,7 @@ class TestRuleModel(BaseTest):
             is_adjacent=False),
         ProjectRule(
             rule_id=400,
-            batch_name='batch_2',
+            task_type_name='batch_2',
             badge='',
             name='rule_4',
             description='',
@@ -992,7 +992,7 @@ class TestRuleModel(BaseTest):
                 rule_id=500)).save()
         RuleModel.from_rule(
             ProjectRule(
-                batch_name='batch_3',
+                task_type_name='batch_3',
                 badge='',
                 name='rule_6',
                 description='',

--- a/tests/gamification/test_query_builders.py
+++ b/tests/gamification/test_query_builders.py
@@ -10,6 +10,7 @@ from vulyk.blueprints.gamification.core.queries import (
     MongoRuleExecutor,
     MongoRuleQueryBuilder)
 from vulyk.blueprints.gamification.core.rules import Rule, ProjectRule
+from vulyk.blueprints.gamification.models.rules import RuleModel
 from vulyk.models.stats import WorkSession
 
 from ..base import BaseTest
@@ -36,7 +37,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_n_tasks_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            task_type_name=project,
+            batch_name=project,
             badge='',
             name='',
             description='',
@@ -78,7 +79,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_n_tasks_m_days_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            task_type_name=project,
+            batch_name=project,
             badge='',
             name='',
             description='',
@@ -128,7 +129,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_n_tasks_weekends_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            task_type_name=project,
+            batch_name=project,
             badge='',
             name='',
             description='',
@@ -179,7 +180,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_m_weekends_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            task_type_name=project,
+            batch_name=project,
             badge='',
             name='',
             description='',
@@ -235,7 +236,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_m_weekends_adjacent_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            task_type_name=project,
+            batch_name=project,
             badge='',
             name='',
             description='',
@@ -296,7 +297,7 @@ class TestMongoQueryBuilder(BaseTest):
     def test_m_days_adjacent_project(self):
         project = 'fake_tasks'
         rule = ProjectRule(
-            task_type_name=project,
+            batch_name=project,
             badge='',
             name='',
             description='',
@@ -331,9 +332,6 @@ class TestMongoQueryExecutor(BaseTest):
     NOW = datetime.now()
     HOUR = timedelta(hours=1)
     DAY = timedelta(days=1)
-
-    def setUp(self):
-        super().setUp()
 
     def tearDown(self):
         WorkSession.drop_collection()
@@ -394,10 +392,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_n_tasks_project_ok(self):
         uid = ObjectId()
-        task_type_name = 'fake_task'
+        batch_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge='',
             name='',
             description='',
@@ -407,14 +405,14 @@ class TestMongoQueryExecutor(BaseTest):
             is_weekend=False,
             is_adjacent=False)
 
-        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.DAY, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.DAY * 2, end_time=self.NOW) \
             .save()
-        WorkSession(user=ObjectId(), task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=ObjectId(), task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
 
         result = MongoRuleExecutor.achieved(
@@ -424,10 +422,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_n_tasks_project_fail(self):
         uid = ObjectId()
-        task_type_name = 'fake_task'
+        batch_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge='',
             name='',
             description='',
@@ -437,14 +435,14 @@ class TestMongoQueryExecutor(BaseTest):
             is_weekend=False,
             is_adjacent=False)
 
-        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.DAY, end_time=self.NOW).save()
-        WorkSession(user=uid, task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=uid, task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.DAY * 2, end_time=self.NOW) \
             .save()
-        WorkSession(user=ObjectId(), task=ObjectId(), task_type=task_type_name,
+        WorkSession(user=ObjectId(), task=ObjectId(), task_type=batch_name,
                     start_time=self.NOW - self.HOUR, end_time=self.NOW).save()
 
         result = MongoRuleExecutor.achieved(
@@ -481,10 +479,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_n_tasks_m_days_project_ok(self):
         uid = ObjectId()
-        task_type_name = 'fake_task'
+        batch_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge='',
             name='',
             description='',
@@ -498,7 +496,7 @@ class TestMongoQueryExecutor(BaseTest):
             day_i = self.NOW - self.DAY * (i % 7)
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=task_type_name,
+                        task_type=batch_name,
                         start_time=day_i,
                         end_time=day_i
                         ).save()
@@ -678,10 +676,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_weekends_project(self):
         uid = ObjectId()
-        task_type_name = 'fake_task'
+        batch_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge='',
             name='',
             description='',
@@ -697,7 +695,7 @@ class TestMongoQueryExecutor(BaseTest):
             day_i = (self.NOW - to_sun) - (self.DAY * 7 * i * 2)
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=task_type_name,
+                        task_type=batch_name,
                         start_time=day_i,
                         end_time=day_i
                         ).save()
@@ -738,10 +736,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_adjacent_weekends_project(self):
         uid = ObjectId()
-        task_type_name = 'fake_task'
+        batch_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge='',
             name='',
             description='',
@@ -757,7 +755,7 @@ class TestMongoQueryExecutor(BaseTest):
             day_i = (self.NOW - to_sun) - (self.DAY * 7 * i)
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=task_type_name,
+                        task_type=batch_name,
                         start_time=day_i,
                         end_time=day_i
                         ).save()
@@ -795,10 +793,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_days_adjacent_project_ok(self):
         uid = ObjectId()
-        task_type_name = 'fake_task'
+        batch_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge='',
             name='',
             description='',
@@ -811,7 +809,7 @@ class TestMongoQueryExecutor(BaseTest):
         for i in range(1, 6):
             WorkSession(user=uid,
                         task=ObjectId(),
-                        task_type=task_type_name,
+                        task_type=batch_name,
                         start_time=self.NOW - self.DAY * i,
                         end_time=self.NOW - self.DAY * i
                         ).save()
@@ -823,10 +821,10 @@ class TestMongoQueryExecutor(BaseTest):
 
     def test_m_days_adjacent_project_fail(self):
         uid = ObjectId()
-        task_type_name = 'fake_task'
+        batch_name = 'fake_task'
         rule = ProjectRule(
             rule_id=100,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge='',
             name='',
             description='',
@@ -848,3 +846,165 @@ class TestMongoQueryExecutor(BaseTest):
             user_id=uid, rule=rule, collection=WorkSession.objects)
 
         self.assertFalse(result)
+
+
+class TestRuleModel(BaseTest):
+    RULES = [
+        Rule(
+            badge='',
+            name='rule_1',
+            description='',
+            bonus=0,
+            tasks_number=3,
+            days_number=0,
+            is_weekend=False,
+            is_adjacent=False,
+            rule_id=100),
+        Rule(
+            badge='',
+            name='rule_2',
+            description='',
+            bonus=10,
+            tasks_number=30,
+            days_number=0,
+            is_weekend=False,
+            is_adjacent=False,
+            rule_id=200),
+        ProjectRule(
+            rule_id=300,
+            batch_name='batch_1',
+            badge='',
+            name='rule_3',
+            description='',
+            bonus=0,
+            tasks_number=40,
+            days_number=0,
+            is_weekend=False,
+            is_adjacent=False),
+        ProjectRule(
+            rule_id=400,
+            batch_name='batch_2',
+            badge='',
+            name='rule_4',
+            description='',
+            bonus=0,
+            tasks_number=0,
+            days_number=5,
+            is_weekend=False,
+            is_adjacent=True),
+    ]
+
+    def setUp(self):
+        super().setUp()
+
+        for rule in self.RULES:
+            RuleModel.from_rule(rule).save()
+
+    def tearDown(self):
+        RuleModel.drop_collection()
+
+        super().tearDown()
+
+    def test_everything_ok(self):
+        self.assertEqual(
+            len(self.RULES),
+            len(RuleModel.get_actual_rules([], None, False))
+        )
+
+    def test_everything_batch_1(self):
+        rules = RuleModel.get_actual_rules([], 'batch_1', False)
+
+        self.assertEqual(3, len(rules))
+        self.assertTrue(any(r.id == 300 for r in rules))
+        self.assertTrue(all(r.id != 400 for r in rules))
+
+    def test_everything_batch_2(self):
+        rules = RuleModel.get_actual_rules([], 'batch_2', False)
+
+        self.assertEqual(3, len(rules))
+        self.assertTrue(any(r.id == 400 for r in rules))
+        self.assertTrue(all(r.id != 300 for r in rules))
+
+    def test_everything_and_weekend(self):
+        RuleModel.from_rule(
+            Rule(
+                badge='',
+                name='rule_5',
+                description='',
+                bonus=0,
+                tasks_number=3,
+                days_number=0,
+                is_weekend=True,
+                is_adjacent=False,
+                rule_id=500)).save()
+        rules = RuleModel.get_actual_rules([], None, True)
+        rules_no_weekend = RuleModel.get_actual_rules([], None, False)
+
+        self.assertEqual(5, len(rules))
+        self.assertTrue(any(r.id == 500 for r in rules))
+
+        self.assertEqual(4, len(rules_no_weekend))
+        self.assertTrue(all(r.id != 500 for r in rules_no_weekend))
+
+    def test_exclude_ids(self):
+        ids = [100, 200]
+        rules = RuleModel.get_actual_rules(ids, None, False)
+
+        self.assertEqual(2, len(rules))
+        self.assertTrue(all(r.id not in ids for r in rules))
+
+    def test_exclude_ids_batch(self):
+        ids = [100, 200]
+        rules = RuleModel.get_actual_rules(ids, 'batch_1', False)
+
+        self.assertEqual(1, len(rules))
+        self.assertTrue(rules[0].id, 300)
+
+    def test_exclude_ids_weekend(self):
+        RuleModel.from_rule(
+            Rule(
+                badge='',
+                name='rule_5',
+                description='',
+                bonus=0,
+                tasks_number=3,
+                days_number=0,
+                is_weekend=True,
+                is_adjacent=False,
+                rule_id=500)).save()
+        ids = [100, 200]
+        rules = RuleModel.get_actual_rules(ids, None, True)
+
+        self.assertEqual(3, len(rules))
+        self.assertTrue(any(r.id == 500 for r in rules))
+
+    def test_exclude_ids_batch_weekend(self):
+        RuleModel.from_rule(
+            Rule(
+                badge='',
+                name='rule_5',
+                description='',
+                bonus=0,
+                tasks_number=3,
+                days_number=0,
+                is_weekend=True,
+                is_adjacent=False,
+                rule_id=500)).save()
+        RuleModel.from_rule(
+            ProjectRule(
+                batch_name='batch_3',
+                badge='',
+                name='rule_6',
+                description='',
+                bonus=0,
+                tasks_number=3,
+                days_number=0,
+                is_weekend=True,
+                is_adjacent=False,
+                rule_id=600)).save()
+        ids = [100, 500]
+        rules = RuleModel.get_actual_rules(ids, 'batch_3', True)
+
+        self.assertEqual(2, len(rules))
+        self.assertTrue(all(r.id in [200, 600] for r in rules))
+        self.assertTrue(all(r.id != 500 for r in rules))

--- a/tests/gamification/test_rule_parsing.py
+++ b/tests/gamification/test_rule_parsing.py
@@ -60,7 +60,7 @@ class TestJsonRulesParsing(BaseTest):
         weekend = True
         adjacent = False
         parsee = {
-            'task_type': project,
+            'batch_name': project,
             'badge': image,
             'name': name,
             'description': descr,
@@ -72,7 +72,7 @@ class TestJsonRulesParsing(BaseTest):
         }
         string = json.dumps(parsee)
         rule = ProjectRule(rule_id=hash(name + project),
-                           task_type_name=project,
+                           batch_name=project,
                            badge=image,
                            name=name,
                            description=descr,

--- a/tests/gamification/test_rule_parsing.py
+++ b/tests/gamification/test_rule_parsing.py
@@ -60,7 +60,7 @@ class TestJsonRulesParsing(BaseTest):
         weekend = True
         adjacent = False
         parsee = {
-            'batch_name': project,
+            'task_type_name': project,
             'badge': image,
             'name': name,
             'description': descr,
@@ -72,7 +72,7 @@ class TestJsonRulesParsing(BaseTest):
         }
         string = json.dumps(parsee)
         rule = ProjectRule(rule_id=hash(name + project),
-                           batch_name=project,
+                           task_type_name=project,
                            badge=image,
                            name=name,
                            description=descr,

--- a/tests/gamification/test_state_models.py
+++ b/tests/gamification/test_state_models.py
@@ -2,7 +2,7 @@
 """
 test_state_models
 """
-from datetime import datetime
+from datetime import datetime, timedelta
 from decimal import Decimal
 
 from vulyk.blueprints.gamification.core.rules import Rule
@@ -18,6 +18,7 @@ from ..fixtures import FakeType
 class TestStateModels(BaseTest):
     TASK_TYPE = FakeType.type_name
     TIMESTAMP = datetime.now()
+    TIMESTAMP_NEXT = TIMESTAMP + timedelta(seconds=1)
     USER = None
 
     def setUp(self):
@@ -30,11 +31,11 @@ class TestStateModels(BaseTest):
     def tearDown(self):
         super().tearDown()
 
-        User.drop_collection()
-        Group.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
 
-        RuleModel.drop_collection()
-        UserStateModel.drop_collection()
+        RuleModel.objects.delete()
+        UserStateModel.objects.delete()
 
     def test_rookie_ok(self):
         state = UserState(
@@ -44,8 +45,7 @@ class TestStateModels(BaseTest):
             actual_coins=Decimal(),
             potential_coins=Decimal(),
             achievements=[],
-            last_changed=self.TIMESTAMP
-        )
+            last_changed=self.TIMESTAMP)
         UserStateModel.from_state(state).save()
         state2 = UserStateModel.objects.get(
             user=self.USER, last_changed=self.TIMESTAMP).to_state()
@@ -61,8 +61,7 @@ class TestStateModels(BaseTest):
             actual_coins=Decimal(),
             potential_coins=Decimal(),
             achievements=[],
-            last_changed=self.TIMESTAMP
-        )
+            last_changed=self.TIMESTAMP)
         UserStateModel.from_state(state).save()
         state2 = UserStateModel.objects.get(
             user=self.USER, last_changed=self.TIMESTAMP).to_state()
@@ -74,7 +73,7 @@ class TestStateModels(BaseTest):
         state = UserState(
             user=self.USER,
             level=0,
-            points=20,
+            points=Decimal(20),
             actual_coins=Decimal(),
             potential_coins=Decimal(),
             achievements=[],
@@ -131,3 +130,233 @@ class TestStateModels(BaseTest):
 
         self.assertEqual(state, state2,
                          'State was not saved and restored just fine')
+
+    def test_usm_update_state_points(self):
+        state = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP)
+        state_model = UserStateModel.from_state(state).save()
+        diff = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(10),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP_NEXT)
+
+        UserStateModel.update_state(diff=diff)
+        new_state = state_model.reload().to_state()
+
+        self.assertEqual(diff, new_state)
+        self.assertEqual(diff.last_changed, new_state.last_changed)
+
+    def test_usm_update_state_level(self):
+        state = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP)
+        state_model = UserStateModel.from_state(state).save()
+        diff = UserState(
+            user=self.USER,
+            level=1,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP_NEXT)
+
+        UserStateModel.update_state(diff=diff)
+        new_state = state_model.reload().to_state()
+
+        self.assertEqual(diff, new_state)
+
+    def test_usm_update_state_actual_coins(self):
+        state = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP)
+        state_model = UserStateModel.from_state(state).save()
+        diff = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(200),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP_NEXT)
+
+        UserStateModel.update_state(diff=diff)
+        new_state = state_model.reload().to_state()
+
+        self.assertEqual(diff, new_state)
+
+    def test_usm_update_state_potential_coins(self):
+        state = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP)
+        state_model = UserStateModel.from_state(state).save()
+        diff = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(300),
+            achievements=[],
+            last_changed=self.TIMESTAMP_NEXT)
+
+        UserStateModel.update_state(diff=diff)
+        new_state = state_model.reload().to_state()
+
+        self.assertEqual(diff, new_state)
+
+    def test_usm_update_state_achievements(self):
+        state = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP)
+        state_model = UserStateModel.from_state(state).save()
+        rule = Rule(
+            badge='',
+            name='',
+            description='',
+            bonus=0,
+            tasks_number=0,
+            days_number=5,
+            is_weekend=False,
+            is_adjacent=True,
+            rule_id=100)
+        RuleModel.from_rule(rule).save()
+        diff = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[rule],
+            last_changed=self.TIMESTAMP_NEXT)
+
+        UserStateModel.update_state(diff=diff)
+        new_state = state_model.reload().to_state()
+
+        self.assertEqual(diff, new_state)
+
+    def test_usm_update_state_all_together(self):
+        state = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP)
+        state_model = UserStateModel.from_state(state).save()
+        rule = Rule(
+            badge='',
+            name='',
+            description='',
+            bonus=0,
+            tasks_number=0,
+            days_number=5,
+            is_weekend=False,
+            is_adjacent=True,
+            rule_id=100)
+        RuleModel.from_rule(rule).save()
+        diff = UserState(
+            user=self.USER,
+            level=80,
+            points=Decimal(200),
+            actual_coins=Decimal(20),
+            potential_coins=Decimal(100),
+            achievements=[rule],
+            last_changed=self.TIMESTAMP_NEXT)
+
+        UserStateModel.update_state(diff=diff)
+        new_state = state_model.reload().to_state()
+
+        self.assertEqual(diff, new_state)
+
+    def test_usm_update_state_twice(self):
+        state = UserState(
+            user=self.USER,
+            level=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
+            achievements=[],
+            last_changed=self.TIMESTAMP)
+        state_model = UserStateModel.from_state(state).save()
+        rule = Rule(
+            badge='',
+            name='Rule 1',
+            description='',
+            bonus=0,
+            tasks_number=0,
+            days_number=5,
+            is_weekend=False,
+            is_adjacent=True,
+            rule_id=100)
+        RuleModel.from_rule(rule).save()
+        rule_two = Rule(
+            badge='',
+            name='Rule 2',
+            description='',
+            bonus=0,
+            tasks_number=0,
+            days_number=5,
+            is_weekend=False,
+            is_adjacent=True,
+            rule_id=200)
+        RuleModel.from_rule(rule_two).save()
+        diff = UserState(
+            user=self.USER,
+            level=80,
+            points=Decimal(200),
+            actual_coins=Decimal(20),
+            potential_coins=Decimal(100),
+            achievements=[rule],
+            last_changed=self.TIMESTAMP_NEXT)
+        diff_two = UserState(
+            user=self.USER,
+            level=81,
+            points=Decimal(50),
+            actual_coins=Decimal(200),
+            potential_coins=Decimal(100),
+            # just by some mistake we passed `rule` twice
+            achievements=[rule, rule_two],
+            last_changed=self.TIMESTAMP_NEXT)
+
+        UserStateModel.update_state(diff=diff)
+        UserStateModel.update_state(diff=diff_two)
+        new_state = state_model.reload().to_state()
+
+        self.assertEqual(new_state.points, diff.points + diff_two.points)
+        self.assertEqual(new_state.level, diff_two.level)
+        self.assertEqual(new_state.actual_coins,
+                         diff.actual_coins + diff_two.actual_coins)
+        self.assertEqual(new_state.potential_coins,
+                         diff.potential_coins + diff_two.potential_coins)
+        self.assertSetEqual(set(new_state.achievements.keys()), {200, 100})
+        self.assertEqual(new_state.last_changed, diff_two.last_changed)

--- a/tests/gamification/test_state_models.py
+++ b/tests/gamification/test_state_models.py
@@ -3,6 +3,7 @@
 test_state_models
 """
 from datetime import datetime
+from decimal import Decimal
 
 from vulyk.blueprints.gamification.core.rules import Rule
 from vulyk.blueprints.gamification.core.state import UserState
@@ -39,9 +40,9 @@ class TestStateModels(BaseTest):
         state = UserState(
             user=self.USER,
             level=0,
-            points=0,
-            actual_coins=0,
-            potential_coins=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
             achievements=[],
             last_changed=self.TIMESTAMP
         )
@@ -56,9 +57,9 @@ class TestStateModels(BaseTest):
         state = UserState(
             user=self.USER,
             level=20,
-            points=0,
-            actual_coins=0,
-            potential_coins=0,
+            points=Decimal(),
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
             achievements=[],
             last_changed=self.TIMESTAMP
         )
@@ -74,8 +75,8 @@ class TestStateModels(BaseTest):
             user=self.USER,
             level=0,
             points=20,
-            actual_coins=0,
-            potential_coins=0,
+            actual_coins=Decimal(),
+            potential_coins=Decimal(),
             achievements=[],
             last_changed=self.TIMESTAMP
         )
@@ -90,9 +91,9 @@ class TestStateModels(BaseTest):
         state = UserState(
             user=self.USER,
             level=0,
-            points=0,
-            actual_coins=50,
-            potential_coins=60,
+            points=Decimal(),
+            actual_coins=Decimal(50),
+            potential_coins=Decimal(60),
             achievements=[],
             last_changed=self.TIMESTAMP
         )
@@ -118,9 +119,9 @@ class TestStateModels(BaseTest):
         state = UserState(
             user=self.USER,
             level=20,
-            points=5000,
-            actual_coins=3240,
-            potential_coins=4000,
+            points=Decimal(5000),
+            actual_coins=Decimal(3240),
+            potential_coins=Decimal(4000),
             achievements=[rule_model],
             last_changed=self.TIMESTAMP
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -33,9 +33,9 @@ class TestAdmin(BaseTest):
                  admin=i % 3 == 0).save()
 
     def tearDown(self):
-        User.drop_collection()
-        Group.drop_collection()
-        Batch.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
+        Batch.objects.delete()
 
         super().tearDown()
 
@@ -85,7 +85,7 @@ class TestBatches(BaseTest):
     WRONG_TASK_TYPE = AnotherTaskType({})
 
     def tearDown(self):
-        Batch.drop_collection()
+        Batch.objects.delete()
 
         super().tearDown()
 

--- a/tests/test_leaderboard.py
+++ b/tests/test_leaderboard.py
@@ -26,11 +26,11 @@ class TestLeaderBoard(BaseTest):
             description='test', id='default', allowed_types=[self.TASK_TYPE])
 
     def tearDown(self):
-        User.drop_collection()
-        Group.drop_collection()
-        AbstractTask.drop_collection()
-        AbstractAnswer.drop_collection()
-        Batch.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
+        AbstractTask.objects.delete()
+        AbstractAnswer.objects.delete()
+        Batch.objects.delete()
 
         super().tearDown()
 

--- a/tests/test_task_types.py
+++ b/tests/test_task_types.py
@@ -35,12 +35,12 @@ class TestTaskTypes(BaseTest):
             description='test', id='default', allowed_types=[self.TASK_TYPE])
 
     def tearDown(self):
-        User.drop_collection()
-        Group.drop_collection()
-        AbstractTask.drop_collection()
-        AbstractAnswer.drop_collection()
-        Batch.drop_collection()
-        WorkSession.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
+        AbstractTask.objects.delete()
+        AbstractAnswer.objects.delete()
+        Batch.objects.delete()
+        WorkSession.objects.delete()
 
         super().tearDown()
 

--- a/tests/test_user_login.py
+++ b/tests/test_user_login.py
@@ -16,8 +16,8 @@ class TestUserLogin(BaseTest):
     USER = User(username='SuperUsername', email='1@email.com', admin=True)
 
     def tearDown(self):
-        User.drop_collection()
-        Group.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
         Group._get_db().drop_collection('user_social_auth')
 
         super().tearDown()

--- a/tests/test_user_login.py
+++ b/tests/test_user_login.py
@@ -2,13 +2,13 @@
 """
 test_user_login
 """
-import flask
-from mongoengine import connect, Document
 from unittest.mock import patch
+
+import flask
+from mongoengine import Document
 
 from vulyk.bootstrap import _social_login as social_login
 from vulyk.models.user import Group, User
-
 from .base import BaseTest
 
 

--- a/tests/test_user_model.py
+++ b/tests/test_user_model.py
@@ -23,8 +23,8 @@ class TestUser(BaseTest):
             description='test', id='default', allowed_types=[self.TASK_TYPE])
 
     def tearDown(self):
-        User.drop_collection()
-        Group.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
 
         super().tearDown()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -22,8 +22,8 @@ class TestUtils(BaseTest):
             allowed_types=[FakeType.type_name])
 
     def tearDown(self):
-        User.drop_collection()
-        Group.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
 
         super().tearDown()
 

--- a/tests/test_worksessions.py
+++ b/tests/test_worksessions.py
@@ -29,11 +29,11 @@ class TestTaskTypes(BaseTest):
             description='test', id='default', allowed_types=[self.TASK_TYPE])
 
     def tearDown(self):
-        User.drop_collection()
-        Group.drop_collection()
-        AbstractTask.drop_collection()
-        AbstractAnswer.drop_collection()
-        WorkSession.drop_collection()
+        User.objects.delete()
+        Group.objects.delete()
+        AbstractTask.objects.delete()
+        AbstractAnswer.objects.delete()
+        WorkSession.objects.delete()
 
         super().tearDown()
 

--- a/vulyk/blueprints/gamification/core/parsing.py
+++ b/vulyk/blueprints/gamification/core/parsing.py
@@ -44,8 +44,8 @@ class JsonRuleParser(RuleParser):
         try:
             parsee = json.loads(json_string)
             name = parsee['name']
-            task_type_name = parsee.get('task_type', '')
-            hash_id = hash('{}{}'.format(name, task_type_name))
+            batch_name = parsee.get('batch_name', '')
+            hash_id = hash('{}{}'.format(name, batch_name))
 
             rule = Rule(rule_id=hash_id,
                         badge=parsee['badge'],
@@ -57,9 +57,8 @@ class JsonRuleParser(RuleParser):
                         is_weekend=bool(parsee['is_weekend']),
                         is_adjacent=bool(parsee['is_adjacent']))
 
-            if task_type_name:
-                return ProjectRule.from_rule(rule,
-                                             parsee['task_type'])
+            if batch_name:
+                return ProjectRule.from_rule(rule, batch_name)
             else:
                 return rule
         except ValueError:

--- a/vulyk/blueprints/gamification/core/parsing.py
+++ b/vulyk/blueprints/gamification/core/parsing.py
@@ -44,8 +44,8 @@ class JsonRuleParser(RuleParser):
         try:
             parsee = json.loads(json_string)
             name = parsee['name']
-            batch_name = parsee.get('batch_name', '')
-            hash_id = hash('{}{}'.format(name, batch_name))
+            task_type_name = parsee.get('task_type_name', '')
+            hash_id = hash('{}{}'.format(name, task_type_name))
 
             rule = Rule(rule_id=hash_id,
                         badge=parsee['badge'],
@@ -57,8 +57,8 @@ class JsonRuleParser(RuleParser):
                         is_weekend=bool(parsee['is_weekend']),
                         is_adjacent=bool(parsee['is_adjacent']))
 
-            if batch_name:
-                return ProjectRule.from_rule(rule, batch_name)
+            if task_type_name:
+                return ProjectRule.from_rule(rule, task_type_name)
             else:
                 return rule
         except ValueError:

--- a/vulyk/blueprints/gamification/core/queries.py
+++ b/vulyk/blueprints/gamification/core/queries.py
@@ -60,7 +60,7 @@ class MongoRuleQueryBuilder(RuleQueryBuilder):
         super().__init__()
 
         if isinstance(rule, ProjectRule):
-            self._filter_first['taskType'] = rule.batch_name
+            self._filter_first['taskType'] = rule.task_type_name
 
         # we filter out tasks older than given date in these cases:
         # - n tasks in m days

--- a/vulyk/blueprints/gamification/core/queries.py
+++ b/vulyk/blueprints/gamification/core/queries.py
@@ -60,7 +60,7 @@ class MongoRuleQueryBuilder(RuleQueryBuilder):
         super().__init__()
 
         if isinstance(rule, ProjectRule):
-            self._filter_first['taskType'] = rule.task_type_name
+            self._filter_first['taskType'] = rule.batch_name
 
         # we filter out tasks older than given date in these cases:
         # - n tasks in m days

--- a/vulyk/blueprints/gamification/core/rules.py
+++ b/vulyk/blueprints/gamification/core/rules.py
@@ -185,12 +185,12 @@ class ProjectRule(Rule):
     Container for project specific rules.
     """
     __slots__ = Rule.__slots__ + [
-        '_task_type_name'
+        '_batch_name'
     ]
 
     def __init__(self,
                  rule_id: int,
-                 task_type_name: str,
+                 batch_name: str,
                  badge: str,
                  name: str,
                  description: str,
@@ -202,8 +202,8 @@ class ProjectRule(Rule):
         """
         :param rule_id: Unique rule identifier.
         :type rule_id: int
-        :param task_type_name: ID of the project/task type.
-        :type task_type_name: str
+        :param batch_name: ID of the batch.
+        :type batch_name: str
         :param badge: Badge image (either base64 or URL)
         :type badge: str
         :param name: Achievement name
@@ -231,28 +231,28 @@ class ProjectRule(Rule):
                          is_weekend=is_weekend,
                          is_adjacent=is_adjacent)
 
-        self._task_type_name = task_type_name
+        self._batch_name = batch_name
 
     @property
-    def task_type_name(self) -> str:
-        return self._task_type_name
+    def batch_name(self) -> str:
+        return self._batch_name
 
     @classmethod
-    def from_rule(cls, rule: Rule, task_type_name: str) -> Rule:
+    def from_rule(cls, rule: Rule, batch_name: str) -> Rule:
         """
         Factory method to extend regular Rule and promote it to ProjectRule
 
         :param rule: Basic Rule instance to copy info from
         :type rule: Rule
-        :param task_type_name: ID of the project/task type.
-        :type task_type_name: str
+        :param batch_name: ID of the project/task type.
+        :type batch_name: str
 
         :return: Fully formed ProjectRule
         :rtype: ProjectRule
         """
         return cls(
             rule_id=rule.id,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge=rule.badge,
             name=rule.name,
             description=rule.description,
@@ -263,10 +263,10 @@ class ProjectRule(Rule):
             is_adjacent=rule.is_adjacent)
 
     def __str__(self) -> str:
-        return 'ProjectRule({name}, {task_type}, {bonus}, {tasks}, {days},' \
+        return 'ProjectRule({name}, {batch}, {bonus}, {tasks}, {days},' \
                ' {week}, {adj})' \
             .format(name=self.name,
-                    task_type=self._task_type_name,
+                    batch=self._batch_name,
                     bonus=self.bonus,
                     tasks=self._tasks_number,
                     days=self._days_number,
@@ -274,9 +274,9 @@ class ProjectRule(Rule):
                     adj=self._is_adjacent)
 
     def __repr__(self) -> str:
-        return 'ProjectRule({name}, {task_type}, {descr})'.format(
+        return 'ProjectRule({name}, {batch}, {descr})'.format(
             name=self.name,
-            task_type=self._task_type_name,
+            batch=self._batch_name,
             descr=self.description[:50] + '...'
         )
 

--- a/vulyk/blueprints/gamification/core/rules.py
+++ b/vulyk/blueprints/gamification/core/rules.py
@@ -185,12 +185,12 @@ class ProjectRule(Rule):
     Container for project specific rules.
     """
     __slots__ = Rule.__slots__ + [
-        '_batch_name'
+        '_task_type_name'
     ]
 
     def __init__(self,
                  rule_id: int,
-                 batch_name: str,
+                 task_type_name: str,
                  badge: str,
                  name: str,
                  description: str,
@@ -202,8 +202,8 @@ class ProjectRule(Rule):
         """
         :param rule_id: Unique rule identifier.
         :type rule_id: int
-        :param batch_name: ID of the batch.
-        :type batch_name: str
+        :param task_type_name: Task type name.
+        :type task_type_name: str
         :param badge: Badge image (either base64 or URL)
         :type badge: str
         :param name: Achievement name
@@ -231,28 +231,28 @@ class ProjectRule(Rule):
                          is_weekend=is_weekend,
                          is_adjacent=is_adjacent)
 
-        self._batch_name = batch_name
+        self._task_type_name = task_type_name
 
     @property
-    def batch_name(self) -> str:
-        return self._batch_name
+    def task_type_name(self) -> str:
+        return self._task_type_name
 
     @classmethod
-    def from_rule(cls, rule: Rule, batch_name: str) -> Rule:
+    def from_rule(cls, rule: Rule, task_type_name: str) -> Rule:
         """
         Factory method to extend regular Rule and promote it to ProjectRule
 
         :param rule: Basic Rule instance to copy info from
         :type rule: Rule
-        :param batch_name: ID of the project/task type.
-        :type batch_name: str
+        :param task_type_name: ID of the project/task type.
+        :type task_type_name: str
 
         :return: Fully formed ProjectRule
         :rtype: ProjectRule
         """
         return cls(
             rule_id=rule.id,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge=rule.badge,
             name=rule.name,
             description=rule.description,
@@ -263,10 +263,10 @@ class ProjectRule(Rule):
             is_adjacent=rule.is_adjacent)
 
     def __str__(self) -> str:
-        return 'ProjectRule({name}, {batch}, {bonus}, {tasks}, {days},' \
+        return 'ProjectRule({name}, {task_type}, {bonus}, {tasks}, {days},' \
                ' {week}, {adj})' \
             .format(name=self.name,
-                    batch=self._batch_name,
+                    task_type=self._task_type_name,
                     bonus=self.bonus,
                     tasks=self._tasks_number,
                     days=self._days_number,
@@ -274,9 +274,9 @@ class ProjectRule(Rule):
                     adj=self._is_adjacent)
 
     def __repr__(self) -> str:
-        return 'ProjectRule({name}, {batch}, {descr})'.format(
+        return 'ProjectRule({name}, {task_type}, {descr})'.format(
             name=self.name,
-            batch=self._batch_name,
+            task_type=self._task_type_name,
             descr=self.description[:50] + '...'
         )
 

--- a/vulyk/blueprints/gamification/core/state.py
+++ b/vulyk/blueprints/gamification/core/state.py
@@ -71,10 +71,11 @@ class UserState:
         try:
             assert self.user is not None, 'User must be present.'
             assert self.level >= 0, 'Level value must be zero or greater.'
-            assert self.points >= 0, 'Points value must be zero or greater.'
-            assert self.actual_coins >= 0, \
+            assert self.points >= Decimal(0), \
+                'Points value must be zero or greater.'
+            assert self.actual_coins >= Decimal(0), \
                 'Actual coins value must be zero or greater.'
-            assert self.potential_coins >= 0, \
+            assert self.potential_coins >= Decimal(0), \
                 'Potential coins value must be zero or greater.'
             assert isinstance(self.achievements, dict), \
                 'Achievements value must be a dict'

--- a/vulyk/blueprints/gamification/listeners.py
+++ b/vulyk/blueprints/gamification/listeners.py
@@ -2,56 +2,101 @@
 from datetime import datetime
 from decimal import Decimal
 
+from vulyk.models.stats import WorkSession
 from vulyk.signals import on_task_done
 
 from .core.events import Event
+from .core.queries import MongoRuleExecutor
+from .core.state import UserState
 from .models.events import EventModel
+from .models.rules import RuleModel
 from .models.state import UserStateModel
 from .models.task_types import (
     AbstractGamifiedTaskType, COINS_PER_TASK_KEY, POINTS_PER_TASK_KEY)
 
+__all__ = [
+    'track_events'
+    'get_actual_rules'
+]
+
 
 @on_task_done.connect
 def track_events(sender, answer) -> None:
+    """
+    The most important gear of the gamification module.
+
+    :param sender:
+    :type sender:
+    :param answer: Current finished task's answer instance
+    :type answer: AbstractAnswer
+
+    :rtype: None
+    """
     from vulyk.app import TASKS_TYPES
 
     task = answer.task
     user = answer.created_by
     batch = task.batch
 
-    if not batch:
-        return
-
-    if batch.task_type not in TASKS_TYPES:
+    if not batch or batch.task_type not in TASKS_TYPES:
         return
 
     if isinstance(TASKS_TYPES[batch.task_type], AbstractGamifiedTaskType):
         dt = datetime.now()  # TODO: TZ Aware?
-
+        # I. Get current/new state
         try:
             state_model = UserStateModel.objects.get(user=user)
         except UserStateModel.DoesNotExist:
             state_model = UserStateModel.objects.create(user=user)
 
-        # state = state_model.to_state()
-        state_model.actual_coins += Decimal(
-            batch.batch_meta[COINS_PER_TASK_KEY])
-        state_model.points += Decimal(batch.batch_meta[POINTS_PER_TASK_KEY])
+        # II. gather earned goods
+        rules = list(filter(
+            lambda rule: MongoRuleExecutor.achieved(
+                user_id=user.id,
+                rule=rule,
+                collection=WorkSession.objects),
+            get_actual_rules(
+                state=state_model.to_state(),
+                batch_name=batch.id,
+                now=dt)))
+        coins_earned = Decimal(batch.batch_meta[COINS_PER_TASK_KEY])
+        points_earned = Decimal(batch.batch_meta[POINTS_PER_TASK_KEY])
+        # TODO: add USM.update_from_state(state) method, save progress
+        # III. Alter the state and create event
+        state_model.actual_coins += coins_earned
+        state_model.points += points_earned
         state_model.last_changed = dt
 
-        # Apparently, it's not possible to update existing state when using
-        # state_model = UserStateModel.from_state(state)
         state_model.save()
 
-        ev = Event.build(
-            timestamp=dt,
-            user=user,
-            answer=answer,
-            points_given=batch.batch_meta[POINTS_PER_TASK_KEY],
-            coins=batch.batch_meta[COINS_PER_TASK_KEY],
-            achievements=[],
-            acceptor_fund=None,
-            level_given=None,
-            viewed=False)
+        EventModel.from_event(
+            Event.build(
+                timestamp=dt,
+                user=user,
+                answer=answer,
+                points_given=batch.batch_meta[POINTS_PER_TASK_KEY],
+                coins=batch.batch_meta[COINS_PER_TASK_KEY],
+                achievements=rules,
+                acceptor_fund=None,
+                level_given=None,
+                viewed=False)
+        ).save()
 
-        EventModel.from_event(ev).save()
+
+def get_actual_rules(state: UserState, batch_name: str, now: datetime) -> list:
+    """
+
+    :param state:
+    :type state:
+    :param batch_name:
+    :type batch_name:
+    :param now:
+    :type now:
+
+    :return:
+    :rtype:
+    """
+    return RuleModel.get_actual_rules(
+        ids=list(state.achievements.keys()),
+        batch_name=batch_name,
+        is_weekend=now.weekday() in [5, 6])

--- a/vulyk/blueprints/gamification/models/rules.py
+++ b/vulyk/blueprints/gamification/models/rules.py
@@ -14,7 +14,7 @@ class RuleModel(Document):
     Database-specific rule representation
     """
     id = IntField(required=True, primary_key=True)
-    batch_name = StringField()
+    task_type_name = StringField()
     badge = StringField(required=True)
     name = StringField(required=True, max_length=255, unique=True)
     description = StringField(required=True)
@@ -29,7 +29,7 @@ class RuleModel(Document):
         'allow_inheritance': True,
         'indexes': [
             'name',
-            'batch_name'
+            'task_type_name'
         ]
     }
 
@@ -44,13 +44,13 @@ class RuleModel(Document):
         :return: New RuleModel instance
         :rtype: RuleModel
         """
-        batch_name = rule.batch_name \
+        task_type_name = rule.task_type_name \
             if isinstance(rule, ProjectRule) \
             else ''
 
         return cls(
             id=rule.id,
-            batch_name=batch_name,
+            task_type_name=task_type_name,
             badge=rule.badge,
             name=rule.name,
             description=rule.description,
@@ -80,27 +80,27 @@ class RuleModel(Document):
             is_adjacent=self.is_adjacent
         )
 
-        if self.batch_name:
+        if self.task_type_name:
             return ProjectRule.from_rule(
                 rule=rule,
-                batch_name=self.batch_name
+                task_type_name=self.task_type_name
             )
         else:
             return rule
 
     @classmethod
     def get_actual_rules(cls: type,
-                         ids: list,
-                         batch_name: str,
+                         skip_ids: list,
+                         task_type_name: str,
                          is_weekend: bool) -> list:
         """
         Prepare the list of rules to apply.
         Cutting off is possible by using different tiny yet smart heuristics.
 
-        :param ids: A list of rules to be skipped for any reason
-        :type ids: list[str]
-        :param batch_name: Name of the batch the task is assigned to
-        :type batch_name: str
+        :param skip_ids: A list of rules to be skipped for any reason
+        :type skip_ids: list[str]
+        :param task_type_name: Name of the project the task is assigned to
+        :type task_type_name: str
         :param is_weekend: It today is a working day, there is no reason to
         check for rules that are weekend-backed.
         :type is_weekend: bool
@@ -110,13 +110,13 @@ class RuleModel(Document):
         """
         base_q = Q()
 
-        if len(ids) > 0:
-            base_q &= Q(id__nin=ids)
+        if len(skip_ids) > 0:
+            base_q &= Q(id__nin=skip_ids)
 
-        if batch_name is not None and len(batch_name) > 0:
-            base_q &= (Q(batch_name=batch_name)
-                       | Q(batch_name='')
-                       | Q(batch_name__exists=False))
+        if task_type_name is not None and len(task_type_name) > 0:
+            base_q &= (Q(task_type_name=task_type_name)
+                       | Q(task_type_name='')
+                       | Q(task_type_name__exists=False))
 
         if not is_weekend:
             base_q &= Q(is_weekend=False)

--- a/vulyk/blueprints/gamification/models/rules.py
+++ b/vulyk/blueprints/gamification/models/rules.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 from flask_mongoengine import Document
-from mongoengine import StringField, IntField, BooleanField
+from mongoengine import StringField, IntField, BooleanField, Q
 
 from ..core.rules import Rule, ProjectRule
 
@@ -14,7 +14,7 @@ class RuleModel(Document):
     Database-specific rule representation
     """
     id = IntField(required=True, primary_key=True)
-    task_type_name = StringField()
+    batch_name = StringField()
     badge = StringField(required=True)
     name = StringField(required=True, max_length=255, unique=True)
     description = StringField(required=True)
@@ -29,7 +29,7 @@ class RuleModel(Document):
         'allow_inheritance': True,
         'indexes': [
             'name',
-            'task_type_name'
+            'batch_name'
         ]
     }
 
@@ -44,13 +44,13 @@ class RuleModel(Document):
         :return: New RuleModel instance
         :rtype: RuleModel
         """
-        task_type_name = rule.task_type_name \
+        batch_name = rule.batch_name \
             if isinstance(rule, ProjectRule) \
             else ''
 
         return cls(
             id=rule.id,
-            task_type_name=task_type_name,
+            batch_name=batch_name,
             badge=rule.badge,
             name=rule.name,
             description=rule.description,
@@ -80,13 +80,48 @@ class RuleModel(Document):
             is_adjacent=self.is_adjacent
         )
 
-        if self.task_type_name:
+        if self.batch_name:
             return ProjectRule.from_rule(
                 rule=rule,
-                task_type_name=self.task_type_name
+                batch_name=self.batch_name
             )
         else:
             return rule
+
+    @classmethod
+    def get_actual_rules(cls: type,
+                         ids: list,
+                         batch_name: str,
+                         is_weekend: bool) -> list:
+        """
+        Prepare the list of rules to apply.
+        Cutting off is possible by using different tiny yet smart heuristics.
+
+        :param ids: A list of rules to be skipped for any reason
+        :type ids: list[str]
+        :param batch_name: Name of the batch the task is assigned to
+        :type batch_name: str
+        :param is_weekend: It today is a working day, there is no reason to
+        check for rules that are weekend-backed.
+        :type is_weekend: bool
+
+        :return: An array of rules to be checked and assigned.
+        :rtype: list[Rule]
+        """
+        base_q = Q()
+
+        if len(ids) > 0:
+            base_q &= Q(id__nin=ids)
+
+        if batch_name is not None and len(batch_name) > 0:
+            base_q &= (Q(batch_name=batch_name)
+                       | Q(batch_name='')
+                       | Q(batch_name__exists=False))
+
+        if not is_weekend:
+            base_q &= Q(is_weekend=False)
+
+        return [rule_model.to_rule() for rule_model in cls.objects(base_q)]
 
     def __str__(self):
         return 'RuleModel({model})'.format(model=str(self.to_rule()))


### PR DESCRIPTION
ADD: Actual rules extraction added. Relies upon earned badges, batch name and current day (check for weekends).
CHG: `Rule`'s and `RuleModel`'s `task_type_name` field renamed to `batch_name` to precisely reflect what it means.
ADD: Signal listener now serves the need to apply actual rules after task is finished to check if any prize must be assigned to user.
ADD: New `UserStateModel.get_or_create_by_user()` and `UserStateModel.update_state()` methods hide all DB-specific logic within the repository.
CHG: Revert back to `BaseQuerySet.objects.delete()` instead of `BaseQuerySet.drop_collection()` because of performance degradation.