### PR TITLE
Global rework. Step 3: Gamification mechanics. Data output 

### DIFF
--- a/docs/vulyk.blueprints.gamification.core.rst
+++ b/docs/vulyk.blueprints.gamification.core.rst
@@ -4,6 +4,22 @@ vulyk.blueprints.gamification.core package
 Submodules
 ----------
 
+vulyk.blueprints.gamification.core.events module
+------------------------------------------------
+
+.. automodule:: vulyk.blueprints.gamification.core.events
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+vulyk.blueprints.gamification.core.foundations module
+-----------------------------------------------------
+
+.. automodule:: vulyk.blueprints.gamification.core.foundations
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 vulyk.blueprints.gamification.core.parsing module
 -------------------------------------------------
 
@@ -26,6 +42,15 @@ vulyk.blueprints.gamification.core.rules module
 -----------------------------------------------
 
 .. automodule:: vulyk.blueprints.gamification.core.rules
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+vulyk.blueprints.gamification.core.state module
+-----------------------------------------------
+
+.. automodule:: vulyk.blueprints.gamification.core.state
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/vulyk.blueprints.gamification.models.rst
+++ b/docs/vulyk.blueprints.gamification.models.rst
@@ -12,11 +12,37 @@ vulyk.blueprints.gamification.models.events module
     :undoc-members:
     :show-inheritance:
 
+vulyk.blueprints.gamification.models.foundations module
+-------------------------------------------------------
+
+.. automodule:: vulyk.blueprints.gamification.models.foundations
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 
 vulyk.blueprints.gamification.models.rules module
 -------------------------------------------------
 
-.. automodule:: vulyk.blueprints.gamification.models
+.. automodule:: vulyk.blueprints.gamification.models.rules
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+vulyk.blueprints.gamification.models.state module
+-------------------------------------------------
+
+.. automodule:: vulyk.blueprints.gamification.models.state
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+vulyk.blueprints.gamification.models.task_types module
+------------------------------------------------------
+
+.. automodule:: vulyk.blueprints.gamification.models.task_types
     :members:
     :undoc-members:
     :show-inheritance:

--- a/docs/vulyk.blueprints.gamification.rst
+++ b/docs/vulyk.blueprints.gamification.rst
@@ -10,6 +10,14 @@ Subpackages
     vulyk.blueprints.gamification.core
     vulyk.blueprints.gamification.models
 
+vulyk.blueprints.gamification.listeners module
+----------------------------------------------
+
+.. automodule:: vulyk.blueprints.gamification.listeners
+:members:
+        :undoc-members:
+        :show-inheritance:
+
 Module contents
 ---------------
 

--- a/tests/gamification/test_fund_models.py
+++ b/tests/gamification/test_fund_models.py
@@ -11,7 +11,7 @@ from vulyk import utils
 from vulyk.blueprints.gamification import gamification
 from vulyk.blueprints.gamification.core.foundations import Fund
 from vulyk.blueprints.gamification.models.foundations import (
-    FundModel, FundFilterKeys)
+    FundModel, FundFilterBy)
 
 from ..base import BaseTest
 
@@ -51,7 +51,7 @@ class TestFundModels(BaseTest):
 
         fund = self._get_fund(self.FUND_ID, self.FUND_NAME)
 
-        resp = app.test_client().get('/gamification/fund/{id}/logo'
+        resp = app.test_client().get('/gamification/funds/{id}/logo'
                                      .format(id=fund.id))
         self.assertEqual(resp.mimetype, 'image/png')
         self.assertEqual(resp.status_code, utils.HTTPStatus.OK)
@@ -74,13 +74,13 @@ class TestFundModels(BaseTest):
         self._get_fund('fund2', 'Fund 2', False)
 
         self.assertEqual(
-            len(list(FundModel.get_all())), 2,
+            len(list(FundModel.get_funds())), 2,
             'Not all funds were fetched')
 
     def test_get_donatable_funds(self):
         self._get_fund('fund1', 'Fund 1'),
         self._get_fund('fund2', 'Fund 2', False)
-        result = list(FundModel.get_all(FundFilterKeys.DONATABLE))
+        result = list(FundModel.get_funds(FundFilterBy.DONATABLE))
 
         self.assertEqual(len(result), 1, 'A single fund must be fetched')
         self.assertEqual(result[0].name, 'Fund 1')
@@ -88,7 +88,7 @@ class TestFundModels(BaseTest):
     def test_get_non_donatable_funds(self):
         self._get_fund('fund1', 'Fund 1'),
         self._get_fund('fund2', 'Fund 2', False)
-        result = list(FundModel.get_all(FundFilterKeys.NON_DONATABLE))
+        result = list(FundModel.get_funds(FundFilterBy.NON_DONATABLE))
 
         self.assertEqual(len(result), 1, 'A single fund must be fetched')
         self.assertEqual(result[0].name, 'Fund 2')

--- a/vulyk/app.py
+++ b/vulyk/app.py
@@ -152,8 +152,7 @@ def skip(type_name, task_id):
         return NO_TASKS
 
     try:
-        task_type.skip_task(user=user._get_current_object(),
-                            task_id=task_id)
+        task_type.skip_task(user=user, task_id=task_id)
     except TaskNotFoundError:
         return NO_TASKS
 
@@ -182,9 +181,7 @@ def done(type_name, task_id):
 
     try:
         task_type.on_task_done(
-            # Mongoengine will shit bricks if it receives LocalProxy object
-            user._get_current_object(),
-            task_id, json.loads(flask.request.form.get('result')))
+            user, task_id, json.loads(flask.request.form.get('result')))
     except TaskNotFoundError:
         return NO_TASKS
 

--- a/vulyk/blueprints/gamification/__init__.py
+++ b/vulyk/blueprints/gamification/__init__.py
@@ -5,8 +5,10 @@ The core of gamification sub-project.
 import flask
 from flask import Blueprint, Response, send_file
 
-from vulyk.blueprints.gamification.models.foundations import FundModel
 from vulyk import utils
+from vulyk.models.user import User
+from vulyk.blueprints.gamification.models.foundations import (
+    FundModel, FundFilterBy)
 
 from . import listeners
 from .models.events import EventModel
@@ -14,7 +16,35 @@ from .models.events import EventModel
 gamification = Blueprint('gamification', __name__)
 
 
-@gamification.route('/fund/<string:fund_id>/logo')
+@gamification.route('/funds', methods=['GET'])
+@gamification.route('/funds/<string:category>', methods=['GET'])
+def funds(category: str = None) -> Response:
+    """
+    The list of foundations we donate to or those, that backed us.
+    May be filtered using `category` parameter that currently takes two values
+    `donatable` and `nondonatable`. If a full list is needed – parameter must
+    be omitted.
+
+    :param category: Filter list
+    :type category: str
+
+    :return: Funds list filtered by category (if passed).
+    :rtype: Response
+    """
+    filtering = FundFilterBy.NO_FILTER
+
+    if category is not None:
+        if category == 'donatable':
+            filtering = FundFilterBy.DONATABLE
+        elif category == 'nondonatable':
+            filtering = FundFilterBy.NON_DONATABLE
+        else:
+            flask.abort(utils.HTTPStatus.NOT_FOUND)
+
+    return utils.json_response({'funds': list(FundModel.get_funds(filtering))})
+
+
+@gamification.route('/funds/<string:fund_id>/logo', methods=['GET'])
 def fund_logo(fund_id: str) -> Response:
     """
     Simple controller that will return you a logotype of the fund if it exists
@@ -40,12 +70,18 @@ def fund_logo(fund_id: str) -> Response:
                      cache_timeout=360000)
 
 
-@gamification.route('/events')
+@gamification.route('/events', methods=['GET'])
 def unseen_events() -> Response:
     """
+    The list of yet unseen events we return for currently logged in user.
 
-    :return:
-    :rtype:
+    :return: Events list (may be empty) or Forbidden if not authorized.
+    :rtype: Response
     """
-    return utils.json_response({
-        'events': EventModel.get_unread_events(flask.g.user)})
+    user = flask.g.user
+
+    if isinstance(user, User):
+        return utils.json_response({
+            'events': EventModel.get_unread_events(flask.g.user)})
+    else:
+        flask.abort(utils.HTTPStatus.FORBIDDEN)

--- a/vulyk/blueprints/gamification/__init__.py
+++ b/vulyk/blueprints/gamification/__init__.py
@@ -9,6 +9,7 @@ from vulyk import utils
 from vulyk.models.user import User
 from vulyk.blueprints.gamification.models.foundations import (
     FundModel, FundFilterBy)
+from vulyk.blueprints.gamification.models.state import UserStateModel
 
 from . import listeners
 from .models.events import EventModel
@@ -83,5 +84,26 @@ def unseen_events() -> Response:
     if isinstance(user, User):
         return utils.json_response({
             'events': EventModel.get_unread_events(flask.g.user)})
+    else:
+        flask.abort(utils.HTTPStatus.FORBIDDEN)
+
+
+@gamification.route('/users/<string:user_id>/state', methods=['GET'])
+def users_state(user_id: str) -> Response:
+    """
+    The collected state of the user within the gamification subsystem.
+    Could be created for the very first time asked (if hasn't yet).
+
+    :param user_id: Needed user ID
+    :type user_id: str
+
+    :return: An response with a state or 404 if user is not found.
+    :rtype: Response
+    """
+    user = User.get_by_id(user_id)
+
+    if isinstance(user, User):
+        state = UserStateModel.get_or_create_by_user(user)
+        return utils.json_response({'state': state.to_dict()})
     else:
         flask.abort(utils.HTTPStatus.FORBIDDEN)

--- a/vulyk/blueprints/gamification/__init__.py
+++ b/vulyk/blueprints/gamification/__init__.py
@@ -9,6 +9,7 @@ from vulyk.blueprints.gamification.models.foundations import FundModel
 from vulyk import utils
 
 from . import listeners
+from .models.events import EventModel
 
 gamification = Blueprint('gamification', __name__)
 
@@ -37,3 +38,14 @@ def fund_logo(fund_id: str) -> Response:
     return send_file(fund.logo,
                      mimetype='image/{}'.format(fund.logo.format.lower()),
                      cache_timeout=360000)
+
+
+@gamification.route('/events')
+def unseen_events() -> Response:
+    """
+
+    :return:
+    :rtype:
+    """
+    return utils.json_response({
+        'events': EventModel.get_unread_events(flask.g.user)})

--- a/vulyk/blueprints/gamification/__init__.py
+++ b/vulyk/blueprints/gamification/__init__.py
@@ -55,7 +55,9 @@ def badges(project: str = None, strictness: str = None) -> Response:
             flask.abort(utils.HTTPStatus.NOT_FOUND)
 
     return utils.json_response(
-        {'badges': RuleModel.get_actual_rules([], filtering, True)})
+        {'badges': map(
+            lambda r: r.to_dict(),
+            RuleModel.get_actual_rules([], filtering, True))})
 
 
 @gamification.route('/funds', methods=['GET'])
@@ -83,7 +85,10 @@ def funds(category: str = None) -> Response:
         else:
             flask.abort(utils.HTTPStatus.NOT_FOUND)
 
-    return utils.json_response({'funds': FundModel.get_funds(filtering)})
+    return utils.json_response(
+        {'funds': map(
+            lambda f: f.to_dict(),
+            FundModel.get_funds(filtering))})
 
 
 @gamification.route('/funds/<string:fund_id>/logo', methods=['GET'])
@@ -124,7 +129,9 @@ def unseen_events() -> Response:
 
     if isinstance(user, User):
         return utils.json_response({
-            'events': EventModel.get_unread_events(flask.g.user)})
+            'events': map(
+                lambda e: e.to_dict(),
+                EventModel.get_unread_events(flask.g.user))})
     else:
         flask.abort(utils.HTTPStatus.FORBIDDEN)
 

--- a/vulyk/blueprints/gamification/listeners.py
+++ b/vulyk/blueprints/gamification/listeners.py
@@ -56,11 +56,10 @@ def track_events(sender, answer) -> None:
                 state=state,
                 task_type_name=batch.task_type,
                 now=dt)))
-
-        # III. Alter the state and create event
         points = batch.batch_meta[POINTS_PER_TASK_KEY]
         coins = batch.batch_meta[COINS_PER_TASK_KEY]
 
+        # III. Alter the state and create event
         UserStateModel.update_state(
             diff=UserState(
                 user=user,

--- a/vulyk/blueprints/gamification/models/events.py
+++ b/vulyk/blueprints/gamification/models/events.py
@@ -73,8 +73,8 @@ class EventModel(Document):
             coins=self.coins,
             achievements=[a.to_rule() for a in self.achievements],
             acceptor_fund=None
-            if self.acceptor_fund is None
-            else self.acceptor_fund.to_fund(),
+                if self.acceptor_fund is None
+                else self.acceptor_fund.to_fund(),
             level_given=self.level_given,
             viewed=self.viewed
         )
@@ -99,8 +99,8 @@ class EventModel(Document):
             achievements=RuleModel.objects(
                 id__in=[r.id for r in event.achievements]),
             acceptor_fund=None
-            if event.acceptor_fund is None
-            else FundModel.objects.get(id=event.acceptor_fund.id),
+                if event.acceptor_fund is None
+                else FundModel.objects.get(id=event.acceptor_fund.id),
             level_given=event.level_given,
             viewed=event.viewed
         )

--- a/vulyk/blueprints/gamification/models/foundations.py
+++ b/vulyk/blueprints/gamification/models/foundations.py
@@ -13,12 +13,12 @@ from mongoengine import (
 from ..core.events import Fund
 
 __all__ = [
-    'FundFilterKeys',
+    'FundFilterBy',
     'FundModel'
 ]
 
 
-class FundFilterKeys(Enum):
+class FundFilterBy(Enum):
     """
     The intent of this enum is to represent filtering policies.
     """
@@ -107,23 +107,25 @@ class FundModel(Document):
         return result
 
     @classmethod
-    def get_all(
-        cls, filter_by: FundFilterKeys = FundFilterKeys.NO_FILTER
+    def get_funds(
+        cls, filter_by: FundFilterBy = FundFilterBy.NO_FILTER
     ) -> Iterator:
         """
+        Returns an enumeration of funds available using the filtering policy
+        passed.
 
-        :param filter_by:
-        :type filter_by: FundFilterKeys
+        :param filter_by: Filtering policy
+        :type filter_by: FundFilterBy
 
-        :return:
+        :return: Lazy enumeration of funds available.
         :rtype: Iterator[Fund]
         """
         criteria = Q()
 
-        if filter_by != FundFilterKeys.NO_FILTER:
-            if filter_by == FundFilterKeys.DONATABLE:
+        if filter_by != FundFilterBy.NO_FILTER:
+            if filter_by == FundFilterBy.DONATABLE:
                 criteria = Q(donatable=True)
-            elif filter_by == FundFilterKeys.NON_DONATABLE:
+            elif filter_by == FundFilterBy.NON_DONATABLE:
                 criteria = Q(donatable=False)
 
         yield from map(lambda f: f.to_fund(), cls.objects(criteria))

--- a/vulyk/bootstrap/_social_login.py
+++ b/vulyk/bootstrap/_social_login.py
@@ -46,7 +46,7 @@ def init_social_login(app, db):
 
     @app.before_request
     def global_user():
-        g.user = login.current_user
+        g.user = login.current_user._get_current_object()
 
     @app.context_processor
     def inject_user():

--- a/vulyk/models/user.py
+++ b/vulyk/models/user.py
@@ -133,6 +133,21 @@ class User(Document, UserMixin):
 
         return document
 
+    @classmethod
+    def get_by_id(cls, user_id: str):
+        """
+
+        :param user_id: Needed user ID
+        :type user_id: str
+
+        :return: The user
+        :rtype: User | None
+        """
+        try:
+            return cls.objects.get(id=user_id)
+        except cls.DoesNotExist:
+            return None
+
     def __str__(self):
         return self.username
 


### PR DESCRIPTION
ADD: New route will return user's unseen events;
ADD: New route will serve as a source of information about available funds;
ADD: New route will return user's state;
ADD: New route to return badges, with either no filtering at all, or filter by projects;

CHG: Auto-documentation fixes;
CHG: Rename `FundFilterKeys` to `FundFilterBy` to be less confusing;
CHG: Global context now contains link to a direct user object instead of `LocalProxy`. This frees us of usage of internal methods like `LocalProxy._get_current_object()`;