### PR TITLE
FIX: Removed ancient `slimit` package in favour of embedded `rjsmin`

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ Jinja2==2.9.6
 MarkupSafe==1.0
 Pillow>=4.0.0,<5.0.0
 pyexecjs>=1.4.0,<2.0.0
-slimit==0.8.1
 social-auth-app-flask<2.0.0
 social-auth-app-flask-mongoengine<2.0.0
 Sphinx==1.6.2

--- a/tests/gamification/fixtures.py
+++ b/tests/gamification/fixtures.py
@@ -4,6 +4,10 @@ from vulyk.blueprints.gamification.models.task_types import \
 
 from ..fixtures import FakeModel, FakeAnswer
 
+__all__ = [
+    'FakeType'
+]
+
 
 class FakeType(AbstractGamifiedTaskType):
     task_model = FakeModel

--- a/vulyk/settings.py
+++ b/vulyk/settings.py
@@ -67,7 +67,7 @@ JS_ASSETS = ['vendor/jquery/jquery.js',
              'scripts/base.js']
 JS_ASSETS_OUTPUT = ENV('JS_ASSETS_OUTPUT', 'scripts/packed.js')
 
-JS_ASSETS_FILTERS = ENV('JS_ASSETS_FILTERS', 'slimit')
+JS_ASSETS_FILTERS = ENV('JS_ASSETS_FILTERS', 'rjsmin')
 
 CSS_ASSETS = ['vendor/bootstrap/bootstrap.css',
               'vendor/jquery.magnific-popup/jquery.magnific-popup.css',


### PR DESCRIPTION
The current version of `slimit` is `0.8.1 (2013-03-26)`. 
Now uses the rJSmin library, which is included with webassets.