### PR TITLE
Add --with-sessions flag to `db export` for inline work session data

### DIFF
--- a/vulyk/cli/db.py
+++ b/vulyk/cli/db.py
@@ -83,7 +83,9 @@ def _load_tasks_file(task_type: AbstractTaskType, path: str, batch: str) -> int:
     return i
 
 
-def export_reports(task_id: AbstractTaskType, path: str, batch: str, *, closed: bool) -> None:
+def export_reports(
+    task_id: AbstractTaskType, path: str, batch: str, *, closed: bool, with_sessions: bool = False
+) -> None:
     """
     Export reports for a given task type.
 
@@ -91,12 +93,13 @@ def export_reports(task_id: AbstractTaskType, path: str, batch: str, *, closed: 
     :param path: Path to export reports to.
     :param batch: Batch ID to export reports for.
     :param closed: Whether to export closed tasks or not.
+    :param with_sessions: Whether to include work session data in the export.
     """
     i = 0
 
     try:
         with open(path, "wb+") as f:
-            for report in task_id.export_reports(batch, closed=closed):
+            for report in task_id.export_reports(batch, closed=closed, with_sessions=with_sessions):
                 f.write(json.dumps(report) + b"\n")
                 i += 1
 

--- a/vulyk/control.py
+++ b/vulyk/control.py
@@ -102,9 +102,16 @@ def load(task_type: str, path: str, meta: tuple[str, str], batch: str) -> None:
     "Passing __all__ will export all tasks of a given type",
 )
 @click.option("--export-all", "export_all", default=False, is_flag=True)
-def export(task_type: str, path: str, batch: str, *, export_all: bool) -> None:
+@click.option(
+    "--with-sessions",
+    "with_sessions",
+    default=False,
+    is_flag=True,
+    help="Include work session timing data (start/end times, duration, activity) in the export.",
+)
+def export(task_type: str, path: str, batch: str, *, export_all: bool, with_sessions: bool) -> None:
     """Exports answers to chosen tasks to json."""
-    _db.export_reports(TASKS_TYPES[task_type], path, batch, closed=not export_all)
+    _db.export_reports(TASKS_TYPES[task_type], path, batch, closed=not export_all, with_sessions=with_sessions)
 
 
 # endregion DB (export/import)


### PR DESCRIPTION
When enabled, each exported answer is enriched with a "session" key containing start_time, end_time, duration, and activity from the WorkSession collection — eliminating the need for external mongoexport workarounds.